### PR TITLE
Update GitHub demos with active projects and latest NuGet packages for Word Library

### DIFF
--- a/Server-side/Accept-all-changes-made-by-an-author/Console-App-.NET-Core/ConsoleApp.csproj
+++ b/Server-side/Accept-all-changes-made-by-an-author/Console-App-.NET-Core/ConsoleApp.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Syncfusion.DocIO.Net.Core" Version="18.3.0.50" />
+    <PackageReference Include="Syncfusion.DocIO.Net.Core" Version="*" />
   </ItemGroup>
 
 </Project>

--- a/Server-side/Reject-insert-delete-revisions-made-by-all-authors/Console-App-.NET-Core/ConsoleApp.csproj
+++ b/Server-side/Reject-insert-delete-revisions-made-by-all-authors/Console-App-.NET-Core/ConsoleApp.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Syncfusion.DocIO.Net.Core" Version="18.3.0.50" />
+    <PackageReference Include="Syncfusion.DocIO.Net.Core" Version="*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
1. Change Syncfusion NuGet versions with * instead of static version in all cross platform samples.
2. Cross platform samples should be .NET 8.0 target. (ASP.NET Core web app, Core console). Change the samples.
3. .NET Framework samples must be .NET 4.6.2 target.
4. Delete projects which reached end of .NET life cycle.